### PR TITLE
perf: combine visitors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug test",
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest.js"
+    }
+  ]
+}

--- a/src/combineVisitors.js
+++ b/src/combineVisitors.js
@@ -72,8 +72,9 @@ export default function combineVisitors(rawVisitors) {
 
             for (const x of visitorLookup[key]) {
               x.call(this, path, ...args);
-              if (path.shouldSkip) {
-                // If the visitor calls path.skip, skip all other visitors in the group
+              // If the visitor calls path.skip, path.remove, or the type changes (path.replace*)
+              // then skip all other visitors in the group
+              if (path.shouldSkip || path.type !== key) {
                 return;
               }
             }

--- a/src/combineVisitors.js
+++ b/src/combineVisitors.js
@@ -4,87 +4,83 @@ import * as t from '@babel/types';
 /**
  * Combines consecutive visitor objects to improve performance by reducing overhead.
  * @warning `CallExpression` is filtered and only called for methods listed in `functionNames`.
- * @param rawVisitors An array of functions and/or visitor objects
+ * @param visitors An array of functions and/or visitor objects
  */
-export default function combineVisitors(rawVisitors) {
-  const processedVisitors = [];
-  let tempVisitorHolder = [];
-
-  // Combine consecutive visitor objects into an array
-  for (const visitor of rawVisitors) {
-    if (typeof visitor === 'object') {
-      tempVisitorHolder.push(visitor);
-      continue;
-    }
-
-    if (tempVisitorHolder.length) {
-      processedVisitors.push(tempVisitorHolder);
-      tempVisitorHolder = [];
-    }
-    processedVisitors.push(visitor);
-  }
-
-  if (tempVisitorHolder.length) {
-    // The last item in visitors was an object
-    processedVisitors.push(tempVisitorHolder);
-  }
-
-  return processedVisitors.map(visitor => {
-    if (!Array.isArray(visitor)) {
-      return visitor;
-    }
-
-    /**
-     * { CallExpression: [visitor1, visitor2, ...], ...}
-     */
-    const visitorLookup = {};
-    /**
-     * {
-     * CallExpression(...args) {
-     *  visitorLookup[CallExpression].forEach(x => x.call(this, ...args))
-     * }
-     */
-    let mainVisitor = {};
-
-    for (const obj of visitor) {
-      _.forOwn(obj, (value, key) => {
-        // Add the visitor to the lookup so it can be called from the mainVisitor
-        if (visitorLookup[key] === undefined) {
-          visitorLookup[key] = [];
+export default function combineVisitors(visitors) {
+  return (
+    visitors
+      // Combine consecutive visitor objects into an array
+      .reduce((accumulator, visitor) => {
+        if (typeof visitor === 'object') {
+          if (accumulator.length && Array.isArray(accumulator[accumulator.length - 1])) {
+            accumulator[accumulator.length - 1].push(visitor);
+          } else {
+            accumulator.push([visitor]);
+          }
+        } else {
+          accumulator.push(visitor);
         }
-        visitorLookup[key].push(value);
-
-        if (mainVisitor[key] !== undefined) {
-          return;
+        return accumulator;
+      }, [])
+      // Convert arrays of consecutive visitor objects to a single visitor object that calls
+      // all visitors in the array
+      .map(visitor => {
+        if (!Array.isArray(visitor)) {
+          return visitor;
         }
 
-        // Create the visitor that will be called by babel
-        mainVisitor = {
-          ...mainVisitor,
-          [key](path, ...args) {
-            // Skip CallExpression visitors if it isn't clsx, classnames, etc.
-            if (key === 'CallExpression') {
-              const c = path.node.callee;
-              if (!t.isIdentifier(c) || !this.options.functionNames.includes(c.name)) {
-                return;
-              }
+        /**
+         * { CallExpression: [visitor1, visitor2, ...], ...}
+         */
+        const visitorLookup = {};
+        /**
+         * {
+         * CallExpression(...args) {
+         *  visitorLookup[CallExpression].forEach(x => x.call(this, ...args))
+         * }
+         */
+        let combinedVisitors = {};
+
+        for (const obj of visitor) {
+          _.forOwn(obj, (value, key) => {
+            // Add the visitor to the lookup so it can be called from the mainVisitor
+            if (visitorLookup[key] === undefined) {
+              visitorLookup[key] = [];
+            }
+            visitorLookup[key].push(value);
+
+            if (combinedVisitors[key] !== undefined) {
+              return;
             }
 
-            for (const x of visitorLookup[key]) {
-              x.call(this, path, ...args);
-              // If the visitor calls path.skip, path.remove, or the type changes (path.replace*)
-              // then skip all other visitors in the group
-              if (path.shouldSkip || path.type !== key) {
-                return;
-              }
-            }
-          },
+            // Create the visitor that will be called by babel
+            combinedVisitors = {
+              ...combinedVisitors,
+              [key](path, ...args) {
+                // Skip CallExpression visitors if it isn't clsx, classnames, etc.
+                if (key === 'CallExpression') {
+                  const c = path.node.callee;
+                  if (!t.isIdentifier(c) || !this.options.functionNames.includes(c.name)) {
+                    return;
+                  }
+                }
+
+                for (const x of visitorLookup[key]) {
+                  x.call(this, path, ...args);
+                  // If the visitor calls path.skip, path.remove, or the type changes (path.replace*)
+                  // then skip all other visitors in the group
+                  if (path.shouldSkip || path.type !== key) {
+                    return;
+                  }
+                }
+              },
+            };
+          });
+        }
+
+        return (path, options) => {
+          path.traverse(combinedVisitors, { options });
         };
-      });
-    }
-
-    return (path, options) => {
-      path.traverse(mainVisitor, { options });
-    };
-  });
+      })
+  );
 }

--- a/src/combineVisitors.js
+++ b/src/combineVisitors.js
@@ -1,0 +1,89 @@
+import _ from 'lodash';
+import * as t from '@babel/types';
+
+/**
+ * Combines consecutive visitor objects to improve performance by reducing overhead.
+ * @warning `CallExpression` is filtered and only called for methods listed in `functionNames`.
+ * @param rawVisitors An array of functions and/or visitor objects
+ */
+export default function combineVisitors(rawVisitors) {
+  const processedVisitors = [];
+  let tempVisitorHolder = [];
+
+  // Combine consecutive visitor objects into an array
+  for (const visitor of rawVisitors) {
+    if (typeof visitor === 'object') {
+      tempVisitorHolder.push(visitor);
+      continue;
+    }
+
+    if (tempVisitorHolder.length) {
+      processedVisitors.push(tempVisitorHolder);
+      tempVisitorHolder = [];
+    }
+    processedVisitors.push(visitor);
+  }
+
+  if (tempVisitorHolder.length) {
+    // The last item in visitors was an object
+    processedVisitors.push(tempVisitorHolder);
+  }
+
+  return processedVisitors.map(visitor => {
+    if (!Array.isArray(visitor)) {
+      return visitor;
+    }
+
+    /**
+     * { CallExpression: [visitor1, visitor2, ...], ...}
+     */
+    const visitorLookup = {};
+    /**
+     * {
+     * CallExpression(...args) {
+     *  visitorLookup[CallExpression].forEach(x => x.call(this, ...args))
+     * }
+     */
+    let mainVisitor = {};
+
+    for (const obj of visitor) {
+      _.forOwn(obj, (value, key) => {
+        // Add the visitor to the lookup so it can be called from the mainVisitor
+        if (visitorLookup[key] === undefined) {
+          visitorLookup[key] = [];
+        }
+        visitorLookup[key].push(value);
+
+        if (mainVisitor[key] !== undefined) {
+          return;
+        }
+
+        // Create the visitor that will be called by babel
+        mainVisitor = {
+          ...mainVisitor,
+          [key](path, ...args) {
+            // Skip CallExpression visitors if it isn't clsx, classnames, etc.
+            if (key === 'CallExpression') {
+              const c = path.node.callee;
+              if (!t.isIdentifier(c) || !this.options.functionNames.includes(c.name)) {
+                return;
+              }
+            }
+
+            for (const x of visitorLookup[key]) {
+              x.call(this, path, ...args);
+              if (path.shouldSkip) {
+                // If the visitor calls path.skip, skip all other visitors in the group
+                return;
+              }
+            }
+          },
+        };
+      });
+    }
+
+    return (path, options) => {
+      path.traverse(mainVisitor, { options });
+    };
+  });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,6 @@ import removeUnnecessaryCalls from './visitors/removeUnnecessaryCalls';
 import createObjectKeyLookups from './visitors/createObjectKeyLookups';
 import collectCalls from './visitors/collectCalls';
 import combineVisitors from './combineVisitors';
-import { performance } from 'perf_hooks';
 
 const visitors = combineVisitors([
   collectCalls,
@@ -25,16 +24,6 @@ const visitors = combineVisitors([
   (path, options) => findFunctionNames(path, { ...options, _removeUnusedImports: true }),
 ]);
 
-let totalTime = 0;
-let totalCount = 0;
-function profile(func) {
-  const before = performance.now();
-  func();
-  const after = performance.now();
-  totalTime += after - before;
-  console.log('Run: %d - Total time: %d', ++totalCount, totalTime);
-}
-
 export default () => ({
   visitor: {
     Program(path, state) {
@@ -45,15 +34,13 @@ export default () => ({
         return;
       }
 
-      profile(() => {
-        try {
-          for (const visitor of visitors) {
-            visitor(path, options);
-          }
-        } catch (err) {
-          throw err;
+      try {
+        for (const visitor of visitors) {
+          visitor(path, options);
         }
-      });
+      } catch (err) {
+        throw err;
+      }
     },
   },
 });

--- a/src/visitors/collectCalls.js
+++ b/src/visitors/collectCalls.js
@@ -1,4 +1,3 @@
-import * as t from '@babel/types';
 import generate from '@babel/generator';
 import fs from 'fs';
 import osPath from 'path';
@@ -6,27 +5,18 @@ import osPath from 'path';
 let stream = null;
 let count = 0;
 
-const visitor = {
+export default {
   CallExpression(path) {
-    const c = path.node.callee;
-    if (!t.isIdentifier(c) || !this.options.functionNames.includes(c.name)) {
+    if (!this.options.collectCalls) {
       return;
+    }
+
+    if (stream === null) {
+      const filePath = osPath.join(__dirname, 'log.js');
+      stream = fs.createWriteStream(filePath, { flags: 'w' });
+      console.log('Writing calls to ' + filePath);
     }
 
     stream.write(`const x${++count} = ${generate(path.node).code};\n\n`);
   },
-};
-
-export default (path, options) => {
-  if (!options.collectCalls) {
-    return;
-  }
-
-  if (stream === null) {
-    const filePath = osPath.join(__dirname, 'log.js');
-    stream = fs.createWriteStream(filePath, { flags: 'w' });
-    console.log('Writing calls to ' + filePath);
-  }
-
-  path.traverse(visitor, { options });
 };

--- a/src/visitors/combineArguments.js
+++ b/src/visitors/combineArguments.js
@@ -2,13 +2,8 @@ import * as t from '@babel/types';
 import _ from 'lodash';
 import * as helpers from '../utils/helpers';
 
-const visitor = {
+export default {
   CallExpression(path) {
-    const c = path.node.callee;
-    if (!t.isIdentifier(c) || !this.options.functionNames.includes(c.name)) {
-      return;
-    }
-
     // Not enough arguments to optimize
     if (path.node.arguments.length < 2) return;
 
@@ -99,8 +94,4 @@ const visitor = {
       }
     }
   },
-};
-
-export default (path, options) => {
-  path.traverse(visitor, { options });
 };

--- a/src/visitors/combineStringLiterals.js
+++ b/src/visitors/combineStringLiterals.js
@@ -1,4 +1,3 @@
-import * as t from '@babel/types';
 import _ from 'lodash';
 import { isStringLike, combineStringLike } from '../utils/strings';
 
@@ -27,18 +26,9 @@ const arrayVisitor = {
   },
 };
 
-const visitor = {
+export default {
   CallExpression(path) {
-    const c = path.node.callee;
-    if (!t.isIdentifier(c) || !this.options.functionNames.includes(c.name)) {
-      return;
-    }
-
     path.node.arguments = combineStringsInArray(path.node.arguments);
     path.traverse(arrayVisitor);
   },
-};
-
-export default (path, options) => {
-  path.traverse(visitor, { options });
 };

--- a/src/visitors/createConditionalExpression.js
+++ b/src/visitors/createConditionalExpression.js
@@ -2,13 +2,8 @@ import * as t from '@babel/types';
 import _ from 'lodash';
 import * as helpers from '../utils/helpers';
 
-const visitor = {
+export default {
   CallExpression(path) {
-    const c = path.node.callee;
-    if (!t.isIdentifier(c) || !this.options.functionNames.includes(c.name)) {
-      return;
-    }
-
     path.node.arguments = combine(path.node.arguments);
 
     function combine(args) {
@@ -97,8 +92,4 @@ const visitor = {
       return [...result, ...operators.map(helpers.createLogicalAndExpression)];
     }
   },
-};
-
-export default (path, options) => {
-  path.traverse(visitor, { options });
 };

--- a/src/visitors/createObjectKeyLookups.js
+++ b/src/visitors/createObjectKeyLookups.js
@@ -101,18 +101,9 @@ const arrayVisitor = {
   },
 };
 
-const visitor = {
+export default {
   CallExpression(path) {
-    const c = path.node.callee;
-    if (!t.isIdentifier(c) || !this.options.functionNames.includes(c.name)) {
-      return;
-    }
-
     path.traverse(arrayVisitor);
     path.node.arguments = combineFromArray(path.node.arguments);
   },
-};
-
-export default (path, options) => {
-  path.traverse(visitor, { options });
 };

--- a/src/visitors/extractObjectProperties.js
+++ b/src/visitors/extractObjectProperties.js
@@ -1,12 +1,7 @@
 import * as t from '@babel/types';
 
-const visitor = {
+export default {
   CallExpression(path) {
-    const c = path.node.callee;
-    if (!t.isIdentifier(c) || !this.options.functionNames.includes(c.name)) {
-      return;
-    }
-
     const args = path.node.arguments;
     const newArguments = [];
 
@@ -28,8 +23,4 @@ const visitor = {
 
     path.node.arguments = newArguments;
   },
-};
-
-export default (path, options) => {
-  path.traverse(visitor, { options });
 };

--- a/src/visitors/removeUnnecessaryCalls.js
+++ b/src/visitors/removeUnnecessaryCalls.js
@@ -105,8 +105,8 @@ const transforms = [
 
 const arrayVisitor = {
   ArrayExpression(path) {
-    for (const t of transforms) {
-      const result = t(path.node.elements);
+    for (const tr of transforms) {
+      const result = tr(path.node.elements);
 
       if (result !== undefined) {
         path.replaceWith(result);
@@ -116,30 +116,22 @@ const arrayVisitor = {
   },
 };
 
-const visitor = {
+export default {
   CallExpression(path) {
-    const c = path.node.callee;
-    if (!t.isIdentifier(c) || !this.options.functionNames.includes(c.name)) {
+    if (!this.options.removeUnnecessaryCalls) {
       return;
     }
 
     path.traverse(arrayVisitor);
 
-    for (const t of transforms) {
-      const result = t(path.node.arguments);
+    for (const tr of transforms) {
+      const result = tr(path.node.arguments);
 
       if (result !== undefined) {
         path.replaceWith(result);
+        path.skip();
         break;
       }
     }
   },
-};
-
-export default (path, options) => {
-  if (!options.removeUnnecessaryCalls) {
-    return;
-  }
-
-  path.traverse(visitor, { options });
 };

--- a/src/visitors/stripLiterals.js
+++ b/src/visitors/stripLiterals.js
@@ -3,13 +3,8 @@ import _ from 'lodash';
 import * as helpers from '../utils/helpers';
 import { isStringLikeEmpty } from '../utils/strings';
 
-const visitor = {
+export default {
   CallExpression(path) {
-    const c = path.node.callee;
-    if (!t.isIdentifier(c) || !this.options.functionNames.includes(c.name)) {
-      return;
-    }
-
     const [match, noMatch] = _.partition(path.node.arguments, helpers.isNestedLogicalAndExpression);
 
     const result = match
@@ -71,8 +66,4 @@ const visitor = {
 
     path.node.arguments = [...rest, ...result];
   },
-};
-
-export default (path, options) => {
-  path.traverse(visitor, { options });
 };


### PR DESCRIPTION
Combine visitors to improve performance by reducing overhead

Time spent optimizing clsx calls

||before|after|change|
|--|--|--|--|
|[material-ui docs](https://github.com/mui-org/material-ui/tree/master/docs) | 1526ms |890ms|-636ms (-41.68%)|
|[@material-ui/core](https://github.com/mui-org/material-ui/tree/master/packages/material-ui)|796ms|515ms|-281ms (-35.3%)|
