### PR TITLE
Updating `clsx` version and using lite module to lower bundle size

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ By default the plugin will remove unnecessary function calls and if all calls ar
 Example of some unnecessary calls
 
 ```javascript
-import clsx from 'clsx';
+import clsx from 'clsx/lite';
 const x = clsx('foo', 'bar');
 const y = clsx({ classA: foo === 'a', classB: foo !== 'a' });
 const z = clsx({

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -1,7 +1,7 @@
 const Benchmark = require('benchmark');
 const path = require('path');
 const fs = require('fs');
-const clsx = require('clsx');
+const clsx = require('clsx/lite');
 const classnames = require('classnames');
 
 function bench(name, { title, before, after }) {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"babel-plugin-tester": "^7.0.3",
 		"benchmark": "^2.1.4",
 		"classnames": "^2.2.6",
-		"clsx": "^1.0.4",
+		"clsx": "^2.1.0",
 		"husky": "^4.2.3",
 		"jest": "^24.9.0",
 		"prettier": "^2.0.1",

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,5 +1,5 @@
 const DefaultSettings = {
-	libraries: ['clsx', 'classnames'],
+	libraries: ['clsx/lite', 'classnames'],
 	functionNames: [] as string[],
 	removeUnnecessaryCalls: true,
 	collectCalls: false,

--- a/test/fixtures/find-function-names/namespace-import/code.js
+++ b/test/fixtures/find-function-names/namespace-import/code.js
@@ -1,3 +1,3 @@
-import * as clsx from 'clsx';
+import * as clsx from 'clsx/lite';
 
 clsx({ foo: true });

--- a/test/fixtures/find-function-names/namespace-import/output.js
+++ b/test/fixtures/find-function-names/namespace-import/output.js
@@ -1,2 +1,2 @@
-import * as clsx from 'clsx';
+import * as clsx from 'clsx/lite';
 clsx('foo');

--- a/test/fixtures/find-function-names/unused-import/code.js
+++ b/test/fixtures/find-function-names/unused-import/code.js
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import clsx from 'clsx/lite';
 const cn = require('classnames');
 
 const x = clsx('foo');

--- a/test/fixtures/find-function-names/using-import/code.js
+++ b/test/fixtures/find-function-names/using-import/code.js
@@ -1,3 +1,3 @@
-import fooFunction from 'clsx';
+import fooFunction from 'clsx/lite';
 
 fooFunction({ foo: true });

--- a/test/fixtures/find-function-names/using-import/output.js
+++ b/test/fixtures/find-function-names/using-import/output.js
@@ -1,2 +1,2 @@
-import fooFunction from 'clsx';
+import fooFunction from 'clsx/lite';
 fooFunction('foo');

--- a/test/fixtures/find-function-names/using-require/code.js
+++ b/test/fixtures/find-function-names/using-require/code.js
@@ -1,3 +1,3 @@
-const fooFunction = require('clsx');
+const fooFunction = require('clsx/lite');
 
 fooFunction({ foo: true });

--- a/test/fixtures/find-function-names/using-require/output.js
+++ b/test/fixtures/find-function-names/using-require/output.js
@@ -1,3 +1,3 @@
-const fooFunction = require('clsx');
+const fooFunction = require('clsx/lite');
 
 fooFunction('foo');

--- a/test/fixtures/proptypes/member-access/code.js
+++ b/test/fixtures/proptypes/member-access/code.js
@@ -1,5 +1,5 @@
+import clsx from 'clsx/lite';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 
 function foo(props) {
 	const x = clsx(props.position === 'top' && classes.x, props.position === 'bottom' && classes.y);

--- a/test/fixtures/proptypes/member-access/output.js
+++ b/test/fixtures/proptypes/member-access/output.js
@@ -1,5 +1,5 @@
+import clsx from 'clsx/lite';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 
 function foo(props) {
 	const x = clsx(props.position === 'top' ? classes.x : classes.y);

--- a/test/fixtures/proptypes/object-pattern-assignment/code.js
+++ b/test/fixtures/proptypes/object-pattern-assignment/code.js
@@ -1,5 +1,5 @@
+import clsx from 'clsx/lite';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 
 function foo(props) {
 	const { position = 'top', anchor: a = 'left' } = props;

--- a/test/fixtures/proptypes/object-pattern-assignment/output.js
+++ b/test/fixtures/proptypes/object-pattern-assignment/output.js
@@ -1,5 +1,5 @@
+import clsx from 'clsx/lite';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 
 function foo(props) {
 	const { position = 'top', anchor: a = 'left' } = props;

--- a/test/fixtures/proptypes/object-pattern-inline/code.js
+++ b/test/fixtures/proptypes/object-pattern-inline/code.js
@@ -1,5 +1,5 @@
+import clsx from 'clsx/lite';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 
 function foo({ position: p }) {
 	const x = clsx(p === 'top' && classes.x, p === 'bottom' && classes.y);

--- a/test/fixtures/proptypes/object-pattern-inline/output.js
+++ b/test/fixtures/proptypes/object-pattern-inline/output.js
@@ -1,5 +1,5 @@
+import clsx from 'clsx/lite';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 
 function foo({ position: p }) {
 	const x = clsx(p === 'top' ? classes.x : classes.y);

--- a/test/fixtures/proptypes/object-pattern-rest/code.js
+++ b/test/fixtures/proptypes/object-pattern-rest/code.js
@@ -1,5 +1,5 @@
+import clsx from 'clsx/lite';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 
 function foo(props) {
 	const { position: p, ...rest } = props;

--- a/test/fixtures/proptypes/object-pattern-rest/output.js
+++ b/test/fixtures/proptypes/object-pattern-rest/output.js
@@ -1,5 +1,5 @@
+import clsx from 'clsx/lite';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 
 function foo(props) {
 	const { position: p, ...rest } = props;

--- a/test/fixtures/proptypes/object-pattern/code.js
+++ b/test/fixtures/proptypes/object-pattern/code.js
@@ -1,5 +1,5 @@
+import clsx from 'clsx/lite';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 
 function foo(props) {
 	const { position: p } = props;

--- a/test/fixtures/proptypes/object-pattern/output.js
+++ b/test/fixtures/proptypes/object-pattern/output.js
@@ -1,5 +1,5 @@
+import clsx from 'clsx/lite';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 
 function foo(props) {
 	const { position: p } = props;

--- a/test/fixtures/proptypes/variable-declaration/code.js
+++ b/test/fixtures/proptypes/variable-declaration/code.js
@@ -1,5 +1,5 @@
+import clsx from 'clsx/lite';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 
 function foo(props) {
 	const p = props.position;

--- a/test/fixtures/proptypes/variable-declaration/output.js
+++ b/test/fixtures/proptypes/variable-declaration/output.js
@@ -1,5 +1,5 @@
+import clsx from 'clsx/lite';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 
 function foo(props) {
 	const p = props.position;

--- a/test/fixtures/referenced-object/transformed-callee/code.js
+++ b/test/fixtures/referenced-object/transformed-callee/code.js
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import clsx from 'clsx/lite';
 
 const stateClasses = {
 	checked: isChecked,

--- a/test/fixtures/referenced-object/transformed-callee/output.js
+++ b/test/fixtures/referenced-object/transformed-callee/output.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var _clsx = _interopRequireDefault(require('clsx'));
+var _lite = _interopRequireDefault(require('clsx/lite'));
 
 function _interopRequireDefault(obj) {
 	return obj && obj.__esModule ? obj : { default: obj };
 }
 
-const stateClasses = (0, _clsx.default)(isChecked && 'checked');
-(0, _clsx.default)(stateClasses);
+const stateClasses = (0, _lite.default)(isChecked && 'checked');
+(0, _lite.default)(stateClasses);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1967,7 +1967,7 @@ __metadata:
     babel-plugin-tester: ^7.0.3
     benchmark: ^2.1.4
     classnames: ^2.2.6
-    clsx: ^1.0.4
+    clsx: ^2.1.0
     find-cache-dir: ^3.2.0
     husky: ^4.2.3
     jest: ^24.9.0
@@ -2316,10 +2316,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "clsx@npm:1.0.4"
-  checksum: bd2a74dbc2fa10d44c5cb083d2ed65da098fd9bc502af767c723becd2f2acb9f09824aac13ed871e93d4afa7c8af5c68b9f3ec99581de157aae7aeee2aca7d2e
+"clsx@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "clsx@npm:2.1.0"
+  checksum: 43fefc29b6b49c9476fbce4f8b1cc75c27b67747738e598e6651dd40d63692135dc60b18fa1c5b78a2a9ba8ae6fd2055a068924b94e20b42039bd53b78b98e1d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes: https://github.com/merceyz/babel-plugin-optimize-clsx/issues/22

I have migrated to the latest version of `clsx` and including the new lite module to lower the bundle size. 

I've ran the tests and went through the code and everything looked fine, do we know any further steps on how we can test this more in depth?